### PR TITLE
fix:correct aortic valve removal by using precise threshold range ins…

### DIFF
--- a/data_extraction/slicing/plane_extract.py
+++ b/data_extraction/slicing/plane_extract.py
@@ -61,7 +61,7 @@ def prepare_meshes(cfg, mesh_path):
         resolution mesh and subsampled mesh.
     """
     case_mesh = pv.get_reader(mesh_path).read()
-    case_mesh = pv.wrap(case_mesh).threshold((cfg.LABELS.AORTA - 1, cfg.LABELS.AORTA + 1),
+    case_mesh = pv.wrap(case_mesh).threshold((cfg.LABELS.AORTA, cfg.LABELS.AORTA),
                                              invert=True,
                                              scalars=cfg.LABELS.LABEL_NAME,
                                              preference='cell')


### PR DESCRIPTION
In the prepare_meshes function of the source code, when removing the aorta section using pv.threshold, the original threshold range (cfg.LABELS.AORTA-1, cfg.LABELS.AORTA+1) uses a closed interval. This inadvertently removes both the right atrium (RA) and aortic valve structures along with the aorta, which subsequently impacts the centroid calculations for the right atrium and aortic valve. The threshold range should be modified to (cfg.LABELS.AORTA, cfg.LABELS.AORTA) to precisely target only the aorta.